### PR TITLE
Bunch of features and fixes for the window picker applet

### DIFF
--- a/mate-netbook.pot
+++ b/mate-netbook.pot
@@ -39,6 +39,16 @@ msgid ""
 "button."
 msgstr ""
 
+#: ../mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in.h:5
+#: ../mate-window-picker-applet/applet.c:338
+msgid "Bold windows title"
+msgstr ""
+
+#: ../mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in.h:6
+#: ../mate-window-picker-applet/applet.c:340
+msgid "Show windows title with a bold face."
+msgstr ""
+
 #: ../mate-window-picker-applet/org.mate.panel.MateWindowPicker.mate-panel-applet.in.in.h:1
 msgid "Window Picker Applet Factory"
 msgstr ""

--- a/mate-netbook.pot
+++ b/mate-netbook.pot
@@ -27,52 +27,64 @@ msgstr ""
 msgid "Show windows from all workspaces."
 msgstr ""
 
+#: ../mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in.h:3
+#: ../mate-window-picker-applet/applet.c:329
+msgid "Show desktop title and logout button"
+msgstr ""
+
+#: ../mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in.h:4
+#: ../mate-window-picker-applet/applet.c:331
+msgid ""
+"Show a title for the desktop when no window is selected, and append a logout "
+"button."
+msgstr ""
+
 #: ../mate-window-picker-applet/org.mate.panel.MateWindowPicker.mate-panel-applet.in.in.h:1
 msgid "Window Picker Applet Factory"
 msgstr ""
 
 #: ../mate-window-picker-applet/org.mate.panel.MateWindowPicker.mate-panel-applet.in.in.h:2
-#: ../mate-window-picker-applet/applet.c:211
-#: ../mate-window-picker-applet/applet.c:212
+#: ../mate-window-picker-applet/applet.c:247
+#: ../mate-window-picker-applet/applet.c:248
 msgid "Window Picker"
 msgstr ""
 
-#: ../mate-window-picker-applet/applet.c:63
+#: ../mate-window-picker-applet/applet.c:65
 msgid "_Preferences"
 msgstr ""
 
-#: ../mate-window-picker-applet/applet.c:66
+#: ../mate-window-picker-applet/applet.c:68
 msgid "_About"
 msgstr ""
 
-#: ../mate-window-picker-applet/applet.c:247
+#: ../mate-window-picker-applet/applet.c:303
 msgid "Preferences"
 msgstr ""
 
-#: ../mate-window-picker-applet/task-title.c:252
-#: ../mate-window-picker-applet/task-title.c:259
-#: ../mate-window-picker-applet/task-title.c:302
-#: ../mate-window-picker-applet/task-title.c:309
-#: ../mate-window-picker-applet/task-title.c:436
-#: ../mate-window-picker-applet/task-title.c:484
-msgid "Home"
-msgstr ""
-
-#: ../mate-window-picker-applet/task-title.c:256
-#: ../mate-window-picker-applet/task-title.c:306
-#: ../mate-window-picker-applet/task-title.c:482
+#: ../mate-window-picker-applet/task-title.c:77
+#: ../mate-window-picker-applet/task-title.c:322
 msgid "Log off, switch user, lock screen or power down the computer"
 msgstr ""
 
-#: ../mate-window-picker-applet/task-title.c:278
+#: ../mate-window-picker-applet/task-title.c:93
+#, c-format
+msgid "There was an error executing '%s': %s"
+msgstr ""
+
+#: ../mate-window-picker-applet/task-title.c:316
+#: ../mate-window-picker-applet/task-title.c:584
+msgid "Desktop"
+msgstr ""
+
+#: ../mate-window-picker-applet/task-title.c:347
 msgid "Close window"
 msgstr ""
 
-#: ../mate-window-picker-applet/task-title.c:457
+#: ../mate-window-picker-applet/task-title.c:608
 msgid "Close"
 msgstr ""
 
-#: ../mate-window-picker-applet/task-title.c:458
+#: ../mate-window-picker-applet/task-title.c:609
 msgid "Close current window."
 msgstr ""
 

--- a/mate-netbook.pot
+++ b/mate-netbook.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-21 15:55+0100\n"
+"POT-Creation-Date: 2019-04-03 19:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,6 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: ../mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in.h:1
+#: ../mate-window-picker-applet/applet.c:320
+msgid "Show all windows"
+msgstr ""
+
+#: ../mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in.h:2
+#: ../mate-window-picker-applet/applet.c:322
 msgid "Show windows from all workspaces."
 msgstr ""
 
@@ -41,10 +47,6 @@ msgstr ""
 
 #: ../mate-window-picker-applet/applet.c:247
 msgid "Preferences"
-msgstr ""
-
-#: ../mate-window-picker-applet/applet.c:264
-msgid "Show windows from all workspaces"
 msgstr ""
 
 #: ../mate-window-picker-applet/task-title.c:252

--- a/mate-window-picker-applet/applet.c
+++ b/mate-window-picker-applet/applet.c
@@ -41,6 +41,7 @@
 #define APPLET_SCHEMA "org.mate.panel.applet.mate-window-picker-applet"
 #define SHOW_WIN_KEY "show-all-windows"
 #define SHOW_HOME_TITLE_KEY "show-home-title"
+#define BOLD_WINDOW_TITLE_KEY "bold-window-title"
 
 typedef struct
 {
@@ -102,6 +103,20 @@ on_show_home_title_changed (GSettings   *settings,
 
   show_home = g_settings_get_boolean (settings, SHOW_HOME_TITLE_KEY);
   g_object_set (app->title, "show_home_title", show_home, NULL);
+}
+
+static void
+on_bold_window_title_changed (GSettings   *settings,
+                              gchar       *key,
+                              gpointer     data)
+{
+  WinPickerApp *app;
+  gboolean bold_win = TRUE;
+
+  app = (WinPickerApp*)data;
+
+  bold_win = g_settings_get_boolean (settings, BOLD_WINDOW_TITLE_KEY);
+  g_object_set (app->title, "bold_window_title", bold_win, NULL);
 }
 
 static inline void
@@ -171,6 +186,8 @@ cw_applet_fill (MatePanelApplet *applet,
                     G_CALLBACK (on_show_all_windows_changed), app);
   g_signal_connect (app->settings, "changed::" SHOW_HOME_TITLE_KEY,
                     G_CALLBACK (on_show_home_title_changed), app);
+  g_signal_connect (app->settings, "changed::" BOLD_WINDOW_TITLE_KEY,
+                    G_CALLBACK (on_bold_window_title_changed), app);
 
   app->applet = GTK_WIDGET (applet);
   force_no_focus_padding (GTK_WIDGET (applet));
@@ -190,6 +207,7 @@ cw_applet_fill (MatePanelApplet *applet,
 
   on_show_all_windows_changed (app->settings, SHOW_WIN_KEY, app);
   on_show_home_title_changed (app->settings, SHOW_HOME_TITLE_KEY, app);
+  on_bold_window_title_changed (app->settings, BOLD_WINDOW_TITLE_KEY, app);
 
   action_group = gtk_action_group_new ("MateWindowPicker Applet Actions");
   gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
@@ -266,6 +284,16 @@ on_show_home_title_checkbox_toggled (GtkToggleButton *check, gpointer null)
 }
 
 static void
+on_bold_window_title_checkbox_toggled (GtkToggleButton *check, gpointer null)
+{
+  gboolean is_active;
+
+  is_active = gtk_toggle_button_get_active (check);
+
+  g_settings_set_boolean (mainapp->settings, BOLD_WINDOW_TITLE_KEY, is_active);
+}
+
+static void
 display_prefs_dialog (GtkAction       *action,
                       WinPickerApp *applet)
 {
@@ -306,6 +334,15 @@ display_prefs_dialog (GtkAction       *action,
                                 g_settings_get_boolean (mainapp->settings, SHOW_HOME_TITLE_KEY));
   g_signal_connect (check, "toggled",
                     G_CALLBACK (on_show_home_title_checkbox_toggled), NULL);
+
+  check = gtk_check_button_new_with_label (_("Bold windows title"));
+  gtk_widget_set_tooltip_text (GTK_WIDGET (check),
+                               _("Show windows title with a bold face."));
+  gtk_box_pack_start (GTK_BOX (vbox), check, FALSE, TRUE, 0);
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (check),
+                                g_settings_get_boolean (mainapp->settings, BOLD_WINDOW_TITLE_KEY));
+  g_signal_connect (check, "toggled",
+                    G_CALLBACK (on_bold_window_title_checkbox_toggled), NULL);
 
   check = gtk_label_new (" ");
   gtk_box_pack_start (GTK_BOX (vbox), check, TRUE, TRUE, 0);

--- a/mate-window-picker-applet/applet.c
+++ b/mate-window-picker-applet/applet.c
@@ -153,7 +153,6 @@ cw_applet_fill (MatePanelApplet *applet,
                 const gchar *iid,
                 gpointer     data)
 {
-  WnckScreen *screen;
   WinPickerApp *app;
   GtkWidget *eb, *tasks, *title;
   gchar *ui_path;
@@ -174,7 +173,6 @@ cw_applet_fill (MatePanelApplet *applet,
 
   app = g_slice_new0 (WinPickerApp);
   mainapp = app;
-  screen = wnck_screen_get_default ();
 
   object_class = G_OBJECT_GET_CLASS (G_OBJECT(applet));
   object_class->finalize = cw_applet_finalize;

--- a/mate-window-picker-applet/applet.c
+++ b/mate-window-picker-applet/applet.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2008 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as 
+ * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
@@ -41,13 +41,13 @@
 #define APPLET_SCHEMA "org.mate.panel.applet.mate-window-picker-applet"
 #define SHOW_WIN_KEY "show-all-windows"
 
-typedef struct 
+typedef struct
 {
   GtkWidget    *tasks;
   GtkWidget    *applet;
   GtkWidget    *title;
   GSettings    *settings;
-  
+
 } WinPickerApp;
 
 static WinPickerApp *mainapp;
@@ -119,8 +119,8 @@ cw_applet_finalize (GObject *object)
 }
 
 static gboolean
-cw_applet_fill (MatePanelApplet *applet, 
-                const gchar *iid, 
+cw_applet_fill (MatePanelApplet *applet,
+                const gchar *iid,
                 gpointer     data)
 {
   WnckScreen *screen;
@@ -129,10 +129,10 @@ cw_applet_fill (MatePanelApplet *applet,
   gchar *ui_path;
   GtkActionGroup *action_group;
   GObjectClass *object_class;
-  
+
   if (strcmp (iid, "MateWindowPicker") != 0)
     return FALSE;
-  	
+
   bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   textdomain (GETTEXT_PACKAGE);
@@ -141,7 +141,7 @@ cw_applet_fill (MatePanelApplet *applet,
   mate_panel_applet_set_background_widget (MATE_PANEL_APPLET (applet), GTK_WIDGET (applet));
 
   wnck_set_client_type (WNCK_CLIENT_TYPE_PAGER);
-  
+
   app = g_slice_new0 (WinPickerApp);
   mainapp = app;
   screen = wnck_screen_get_default ();
@@ -170,7 +170,7 @@ cw_applet_fill (MatePanelApplet *applet,
   gtk_box_pack_start (GTK_BOX (eb), title, TRUE, TRUE, 0);
 
   gtk_widget_show_all (GTK_WIDGET (applet));
-	
+
   on_show_all_windows_changed (app->settings, SHOW_WIN_KEY, app);
 		
   action_group = gtk_action_group_new ("MateWindowPicker Applet Actions");
@@ -185,11 +185,11 @@ cw_applet_fill (MatePanelApplet *applet,
   g_free (ui_path);
   g_object_unref (action_group);
 
-  mate_panel_applet_set_flags (MATE_PANEL_APPLET (applet), 
+  mate_panel_applet_set_flags (MATE_PANEL_APPLET (applet),
                                MATE_PANEL_APPLET_EXPAND_MAJOR
                                | MATE_PANEL_APPLET_EXPAND_MINOR
                                | MATE_PANEL_APPLET_HAS_HANDLE);
-	
+
   return TRUE;
 }
 
@@ -204,7 +204,7 @@ display_about_dialog (GtkAction       *action,
                       WinPickerApp *applet)
 {
   GtkWidget *panel_about_dialog;
-	
+
   panel_about_dialog = gtk_about_dialog_new ();
 
   g_object_set (panel_about_dialog,
@@ -231,7 +231,7 @@ static void
 on_checkbox_toggled (GtkToggleButton *check, gpointer null)
 {
   gboolean is_active;
-    
+
   is_active = gtk_toggle_button_get_active (check);
 
   g_settings_set_boolean (mainapp->settings, SHOW_WIN_KEY, is_active);
@@ -272,16 +272,16 @@ display_prefs_dialog (GtkAction       *action,
   gtk_box_pack_start (GTK_BOX (vbox), check, TRUE, TRUE, 0);
 
   gtk_widget_set_size_request (nb, -1, 100);
-  
+
   hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start (GTK_BOX (box), hbox, FALSE, FALSE, 0);
-  
+
   label = gtk_label_new (" ");
   gtk_box_pack_start (GTK_BOX (hbox), label, TRUE, TRUE, 0);
 
   button = gtk_button_new_from_stock (GTK_STOCK_CLOSE);
   gtk_box_pack_start (GTK_BOX (hbox), button, FALSE, FALSE, 0);
-	
+
   gtk_widget_show_all (window);
 
   g_signal_connect (window, "delete-event",
@@ -291,6 +291,6 @@ display_prefs_dialog (GtkAction       *action,
                     G_CALLBACK (gtk_widget_destroy), window);
   g_signal_connect_swapped (button, "clicked",
                             G_CALLBACK (gtk_widget_destroy), window);
-	
+
   gtk_window_present (GTK_WINDOW (window));
 }

--- a/mate-window-picker-applet/applet.c
+++ b/mate-window-picker-applet/applet.c
@@ -228,7 +228,7 @@ display_about_dialog (GtkAction       *action,
 }
 
 static void
-on_checkbox_toggled (GtkToggleButton *check, gpointer null)
+on_show_win_key_checkbox_toggled (GtkToggleButton *check, gpointer null)
 {
   gboolean is_active;
 
@@ -261,12 +261,14 @@ display_prefs_dialog (GtkAction       *action,
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 8);
   gtk_notebook_append_page (GTK_NOTEBOOK (nb), vbox, NULL);
 
-  check = gtk_check_button_new_with_label (_("Show windows from all workspaces"));
+  check = gtk_check_button_new_with_label (_("Show all windows"));
+  gtk_widget_set_tooltip_text (GTK_WIDGET (check),
+                               _("Show windows from all workspaces."));
   gtk_box_pack_start (GTK_BOX (vbox), check, FALSE, TRUE, 0);
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (check),
                                 g_settings_get_boolean (mainapp->settings, SHOW_WIN_KEY));
   g_signal_connect (check, "toggled",
-                    G_CALLBACK (on_checkbox_toggled), NULL);
+                    G_CALLBACK (on_show_win_key_checkbox_toggled), NULL);
 
   check = gtk_label_new (" ");
   gtk_box_pack_start (GTK_BOX (vbox), check, TRUE, TRUE, 0);

--- a/mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in
+++ b/mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in
@@ -5,5 +5,10 @@
       <summary>Show all windows</summary>
       <description>Show windows from all workspaces.</description>
     </key>
+    <key name="show-home-title" type="b">
+      <default>false</default>
+      <summary>Show desktop title and logout button</summary>
+      <description>Show a title for the desktop when no window is selected, and append a logout button.</description>
+    </key>
   </schema>
 </schemalist>

--- a/mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in
+++ b/mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in
@@ -2,7 +2,7 @@
   <schema id="org.mate.panel.applet.mate-window-picker-applet">
     <key name="show-all-windows" type="b">
       <default>true</default>
-      <summary>Show windows from all workspaces.</summary>
+      <summary>Show all windows</summary>
       <description>Show windows from all workspaces.</description>
     </key>
   </schema>

--- a/mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in
+++ b/mate-window-picker-applet/org.mate.panel.applet.mate-window-picker-applet.gschema.xml.in
@@ -10,5 +10,10 @@
       <summary>Show desktop title and logout button</summary>
       <description>Show a title for the desktop when no window is selected, and append a logout button.</description>
     </key>
+    <key name="bold-window-title" type="b">
+      <default>true</default>
+      <summary>Bold windows title</summary>
+      <description>Show windows title with a bold face.</description>
+    </key>
   </schema>
 </schemalist>

--- a/mate-window-picker-applet/task-list.c
+++ b/mate-window-picker-applet/task-list.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2008 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as 
+ * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
@@ -39,7 +39,7 @@ struct _TaskListPrivate
 enum
 {
   PROP_0,
-  
+
   PROP_SHOW_ALL_WINDOWS
 };
 
@@ -78,9 +78,9 @@ on_window_opened (WnckScreen *screen,
       || type == WNCK_WINDOW_SPLASHSCREEN
       || type == WNCK_WINDOW_MENU)
     return;
-    
+
   GtkWidget *item = task_item_new (window);
-  
+
   if (item)
   {
     gtk_box_pack_start (GTK_BOX (list), item, FALSE, FALSE, 0);
@@ -183,11 +183,11 @@ task_list_new (void)
 {
   GtkWidget *list = NULL;
 
-  list = g_object_new (TASK_TYPE_LIST, 
-                       "homogeneous", FALSE, 
-                       "spacing", 0, 
+  list = g_object_new (TASK_TYPE_LIST,
+                       "homogeneous", FALSE,
+                       "spacing", 0,
                        NULL);
-  
+
   return list;
 }
 
@@ -202,7 +202,7 @@ task_list_get_default (void)
   return list;
 }
 
-gboolean    
+gboolean
 task_list_get_desktop_visible (TaskList *list)
 {
   GList *windows, *w;
@@ -214,7 +214,7 @@ task_list_get_desktop_visible (TaskList *list)
   for (w = windows; w; w = w->next)
   {
     WnckWindow *window;
-    
+
     window = w->data;
 
     if (WNCK_IS_WINDOW (window) && !wnck_window_is_minimized (window))
@@ -229,4 +229,3 @@ task_list_get_show_all_windows (TaskList *list)
 {
   return list->priv->show_all_windows;
 }
-

--- a/mate-window-picker-applet/task-list.c
+++ b/mate-window-picker-applet/task-list.c
@@ -93,10 +93,6 @@ on_window_opened (WnckScreen *screen,
 static void
 task_list_finalize (GObject *object)
 {
-  TaskListPrivate *priv;
-
-  priv = TASK_LIST_GET_PRIVATE (object);
-
   G_OBJECT_CLASS (task_list_parent_class)->finalize (object);
 }
 

--- a/mate-window-picker-applet/task-title.c
+++ b/mate-window-picker-applet/task-title.c
@@ -63,8 +63,6 @@ start_logout_dialog (TaskTitle *title)
 {
   GError *error = NULL;
   GAppInfo *app_info;
-  GdkAppLaunchContext *launch_context;
-  GdkDisplay *display;
   GdkScreen *gdkscreen;
 
   g_return_val_if_fail (TASK_IS_TITLE (title), FALSE);
@@ -75,6 +73,8 @@ start_logout_dialog (TaskTitle *title)
     G_APP_INFO_CREATE_NONE, &error);
 
   if (!error) {
+    GdkDisplay *display;
+    GdkAppLaunchContext *launch_context;
     display = gdk_screen_get_display (gdkscreen);
     launch_context = gdk_display_get_app_launch_context (display);
     gdk_app_launch_context_set_screen (launch_context, gdkscreen);
@@ -84,7 +84,6 @@ start_logout_dialog (TaskTitle *title)
   }
 
   GtkWidget *dialog;
-
   dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_DESTROY_WITH_PARENT,
                                    GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
                                    _("There was an error executing '%s': %s"),
@@ -373,7 +372,6 @@ on_button_release (GtkWidget *title, GdkEventButton *event)
 {
   TaskTitlePrivate *priv;
   WnckWindow *window;
-  GtkWidget *menu;
 
   g_return_val_if_fail (TASK_IS_TITLE (title), FALSE);
   priv = TASK_TITLE_GET_PRIVATE (title);
@@ -386,6 +384,7 @@ on_button_release (GtkWidget *title, GdkEventButton *event)
   {
     if (wnck_window_get_window_type (window) != WNCK_WINDOW_DESKTOP)
     {
+      GtkWidget *menu;
       menu = wnck_action_menu_new (window);
       gtk_menu_popup_at_pointer (GTK_MENU (menu), (GdkEvent*)event);
       return TRUE;
@@ -554,7 +553,6 @@ task_title_init (TaskTitle *title)
   TaskTitlePrivate *priv;
   GdkScreen *gdkscreen;
   GtkIconTheme *theme;
-  GdkPixbuf *pixbuf;
   AtkObject *atk;
   int width, height;
 

--- a/mate-window-picker-applet/task-title.c
+++ b/mate-window-picker-applet/task-title.c
@@ -25,8 +25,6 @@
 
 #include <math.h>
 
-#include "task-list.h"
-
 G_DEFINE_TYPE (TaskTitle, task_title, GTK_TYPE_EVENT_BOX);
 
 #define TASK_TITLE_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj),\
@@ -257,17 +255,20 @@ on_active_window_changed (WnckScreen *screen,
       gtk_label_set_text (GTK_LABEL (priv->label), _("Home"));
       gtk_image_set_from_pixbuf (GTK_IMAGE (priv->button_image),
                                  priv->quit_icon);
+
+      gtk_widget_set_tooltip_text (GTK_WIDGET (title), NULL);
       gtk_widget_set_tooltip_text (priv->button,
-                                _("Log off, switch user, lock screen or power "
-                                     "down the computer"));
-      gtk_widget_set_tooltip_text (GTK_WIDGET (title),
-                                   _("Home"));      gtk_widget_show (priv->box);
+                                   _("Log off, switch user, lock screen or "
+                                     "power down the computer"));
+
+      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_ACTIVE);
+      gtk_widget_show (priv->box);
     }
     else
     {
-      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
       gtk_widget_set_tooltip_text (priv->button, NULL);
       gtk_widget_set_tooltip_text (GTK_WIDGET (title), NULL);
+      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
       gtk_widget_hide (priv->box);
     }
   }
@@ -288,42 +289,18 @@ on_active_window_changed (WnckScreen *screen,
                       G_CALLBACK (on_icon_changed), title);
     g_signal_connect_after (act_window, "state-changed",
                             G_CALLBACK (on_state_changed), title);
-    gtk_widget_show (priv->box);
     priv->window = act_window;
-  }
-
-  if (WNCK_IS_WINDOW (act_window)
-      && !wnck_window_is_maximized (act_window)
-      && (priv->show_home_title ? type != WNCK_WINDOW_DESKTOP : 1))
-  {
-    gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
-    gtk_widget_hide (priv->box);
-  }
-  else if (!WNCK_IS_WINDOW (act_window))
-  {
-    if (task_list_get_desktop_visible (TASK_LIST (task_list_get_default ()))
-        && priv->show_home_title)
+    if (wnck_window_is_maximized (act_window))
     {
-      gtk_label_set_text (GTK_LABEL (priv->label), _("Home"));
-      gtk_image_set_from_pixbuf (GTK_IMAGE (priv->button_image),
-                                 priv->quit_icon);
-      gtk_widget_set_tooltip_text (priv->button,
-                                _("Log off, switch user, lock screen or power "
-                                     "down the computer"));
-      gtk_widget_set_tooltip_text (GTK_WIDGET (title),
-                                   _("Home"));
+      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_ACTIVE);
       gtk_widget_show (priv->box);
-     }
+    }
     else
     {
       gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
-      gtk_widget_set_tooltip_text (priv->button, NULL);
-      gtk_widget_set_tooltip_text (GTK_WIDGET (title), NULL);
       gtk_widget_hide (priv->box);
     }
   }
-  else
-    gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_ACTIVE);
 
   gtk_widget_queue_draw (GTK_WIDGET (title));
 }

--- a/mate-window-picker-applet/task-title.c
+++ b/mate-window-picker-applet/task-title.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2008 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as 
+ * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
@@ -54,8 +54,8 @@ struct _TaskTitlePrivate
 static void disconnect_window (TaskTitle *title);
 
 static gboolean
-on_close_clicked (GtkButton *button, 
-                  GdkEventButton *event, 
+on_close_clicked (GtkButton *button,
+                  GdkEventButton *event,
                   TaskTitle *title)
 {
   TaskTitlePrivate *priv;
@@ -87,10 +87,10 @@ on_enter_notify (GtkWidget *widget,
                  TaskTitle *title)
 {
   g_return_val_if_fail (TASK_IS_TITLE (title), FALSE);
-  
+
   title->priv->mouse_in_close_button = TRUE;
   gtk_widget_queue_draw (widget);
-  
+
   return FALSE;
 }
 
@@ -100,7 +100,7 @@ on_leave_notify (GtkWidget *widget,
                  TaskTitle *title)
 {
   g_return_val_if_fail (TASK_IS_TITLE (title), FALSE);
-  
+
   title->priv->mouse_in_close_button = FALSE;
   gtk_widget_queue_draw (widget);
 
@@ -108,7 +108,7 @@ on_leave_notify (GtkWidget *widget,
 }
 
 static gboolean
-on_button_draw (GtkWidget *widget, 
+on_button_draw (GtkWidget *widget,
                 cairo_t *cr,
                 TaskTitle *title)
 {
@@ -116,7 +116,7 @@ on_button_draw (GtkWidget *widget,
 
   TaskTitlePrivate *priv;
   priv = title->priv;
-  
+
   if (priv->mouse_in_close_button)
   {
     GtkStyle *style = gtk_widget_get_style (widget);
@@ -201,7 +201,7 @@ on_state_changed (WnckWindow *window,
   {
     gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
     gtk_widget_hide (priv->box);
-  }  
+  }
 }
 
 static void
@@ -224,7 +224,7 @@ on_active_window_changed (WnckScreen *screen,
   TaskTitlePrivate *priv;
   WnckWindow *act_window;
   WnckWindowType type = WNCK_WINDOW_NORMAL;
-  
+
   g_return_if_fail (TASK_IS_TITLE (title));
   priv = title->priv;
 
@@ -241,16 +241,16 @@ on_active_window_changed (WnckScreen *screen,
       || type == WNCK_WINDOW_SPLASHSCREEN
       || type == WNCK_WINDOW_MENU)
     return;
- 
+
   disconnect_window (title);
 
   if (!WNCK_IS_WINDOW (act_window)
         || wnck_window_get_window_type (act_window) == WNCK_WINDOW_DESKTOP)
-  { 
+  {
     if (priv->show_home_title)
     {
       gtk_label_set_text (GTK_LABEL (priv->label), _("Home"));
-      gtk_image_set_from_pixbuf (GTK_IMAGE (priv->button_image), 
+      gtk_image_set_from_pixbuf (GTK_IMAGE (priv->button_image),
                                  priv->quit_icon);
       gtk_widget_set_tooltip_text (priv->button,
                                 _("Log off, switch user, lock screen or power "
@@ -268,7 +268,7 @@ on_active_window_changed (WnckScreen *screen,
   }
   else
   {
-    gtk_label_set_text (GTK_LABEL (priv->label), 
+    gtk_label_set_text (GTK_LABEL (priv->label),
                         wnck_window_get_name (act_window));
     gtk_image_set_from_icon_name (GTK_IMAGE (priv->button_image),
                                   "window-close", GTK_ICON_SIZE_MENU);
@@ -283,7 +283,7 @@ on_active_window_changed (WnckScreen *screen,
                       G_CALLBACK (on_icon_changed), title);
     g_signal_connect_after (act_window, "state-changed",
                             G_CALLBACK (on_state_changed), title);
-    gtk_widget_show (priv->box);  
+    gtk_widget_show (priv->box);
     priv->window = act_window;
   }
 
@@ -300,17 +300,17 @@ on_active_window_changed (WnckScreen *screen,
         && priv->show_home_title)
     {
       gtk_label_set_text (GTK_LABEL (priv->label), _("Home"));
-      gtk_image_set_from_pixbuf (GTK_IMAGE (priv->button_image), 
+      gtk_image_set_from_pixbuf (GTK_IMAGE (priv->button_image),
                                  priv->quit_icon);
       gtk_widget_set_tooltip_text (priv->button,
                                 _("Log off, switch user, lock screen or power "
                                      "down the computer"));
       gtk_widget_set_tooltip_text (GTK_WIDGET (title),
-                                   _("Home"));      
+                                   _("Home"));
       gtk_widget_show (priv->box);
      }
     else
-    {  
+    {
       gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
       gtk_widget_set_tooltip_text (priv->button, NULL);
       gtk_widget_set_tooltip_text (GTK_WIDGET (title), NULL);
@@ -342,7 +342,7 @@ on_button_release (GtkWidget *title, GdkEventButton *event)
     if (wnck_window_get_window_type (window) != WNCK_WINDOW_DESKTOP)
     {
       menu = wnck_action_menu_new (window);
-      gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL, 
+      gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL,
                       event->button, event->time);
       return TRUE;
     }
@@ -354,7 +354,7 @@ on_button_release (GtkWidget *title, GdkEventButton *event)
       wnck_window_unmaximize (window);
     }
   }
-  
+
   return FALSE;
 }
 
@@ -411,7 +411,7 @@ task_title_init (TaskTitle *title)
   GdkPixbuf *pixbuf;
   AtkObject *atk;
   int width, height;
-    	
+
   priv = title->priv = TASK_TITLE_GET_PRIVATE (title);
 
   priv->screen = wnck_screen_get_default ();
@@ -424,7 +424,7 @@ task_title_init (TaskTitle *title)
   gtk_widget_add_events (GTK_WIDGET (title), GDK_ALL_EVENTS_MASK);
 
   priv->align = gtk_alignment_new (0.0, 0.5, 1.0, 1.0);
-  gtk_alignment_set_padding (GTK_ALIGNMENT (priv->align), 
+  gtk_alignment_set_padding (GTK_ALIGNMENT (priv->align),
                              0, 0, 6, 6);
   gtk_container_add (GTK_CONTAINER (title), priv->align);
 
@@ -446,19 +446,19 @@ task_title_init (TaskTitle *title)
   gtk_box_pack_start (GTK_BOX (priv->box), priv->label, TRUE, TRUE, 0);
   gtk_widget_show (priv->label);
 
-  priv->button = g_object_new (GTK_TYPE_EVENT_BOX, 
+  priv->button = g_object_new (GTK_TYPE_EVENT_BOX,
                                "visible-window", FALSE,
                                "above-child", TRUE,
                                NULL);
   gtk_box_pack_start (GTK_BOX (priv->box), priv->button, FALSE, FALSE, 0);
   gtk_widget_show (priv->button);
-  
+
   atk = gtk_widget_get_accessible (priv->button);
   atk_object_set_name (atk, _("Close"));
   atk_object_set_description (atk, _("Close current window."));
   atk_object_set_role (atk, ATK_ROLE_PUSH_BUTTON);
-  
-  g_signal_connect (priv->button, "button-release-event", 
+
+  g_signal_connect (priv->button, "button-release-event",
                     G_CALLBACK (on_close_clicked), title);
   g_signal_connect (priv->button, "enter-notify-event",
                     G_CALLBACK (on_enter_notify), title);
@@ -481,16 +481,16 @@ task_title_init (TaskTitle *title)
   gtk_widget_set_tooltip_text (priv->button,
                                _("Log off, switch user, lock screen or power "
                                  "down the computer"));
-  gtk_widget_set_tooltip_text (GTK_WIDGET (title), _("Home"));  
+  gtk_widget_set_tooltip_text (GTK_WIDGET (title), _("Home"));
 
   if (priv->show_home_title)
     gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_ACTIVE);
   else
     gtk_widget_hide (priv->box);
- 
+
 
   gtk_widget_add_events (GTK_WIDGET (title), GDK_ALL_EVENTS_MASK);
- 
+
   g_signal_connect (priv->screen, "active-window-changed",
                     G_CALLBACK (on_active_window_changed), title);
   g_signal_connect (title, "button-press-event",
@@ -503,10 +503,10 @@ task_title_new (void)
 {
   GtkWidget *title = NULL;
 
-  title = g_object_new (TASK_TYPE_TITLE, 
-                        "border-width", 0, 
+  title = g_object_new (TASK_TYPE_TITLE,
+                        "border-width", 0,
                         "name", "tasklist-button",
-                        "visible-window", FALSE, 
+                        "visible-window", FALSE,
                         NULL);
 
   return title;

--- a/mate-window-picker-applet/task-title.c
+++ b/mate-window-picker-applet/task-title.c
@@ -74,7 +74,12 @@ on_close_clicked (GtkButton *button,
   {
     if (priv->window == window)
       disconnect_window (title);
-    wnck_window_close (window, event->time);
+    // event->time is buggy, thus we have to workaroud this
+    GdkScreen *gdkscreen;
+    GdkDisplay *display;
+    gdkscreen = gtk_widget_get_screen (GTK_WIDGET (title));
+    display = gdk_screen_get_display (gdkscreen);
+    wnck_window_close (window, gdk_x11_display_get_user_time (display));
   }
   gtk_widget_queue_draw (GTK_WIDGET (title));
 
@@ -342,8 +347,7 @@ on_button_release (GtkWidget *title, GdkEventButton *event)
     if (wnck_window_get_window_type (window) != WNCK_WINDOW_DESKTOP)
     {
       menu = wnck_action_menu_new (window);
-      gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL,
-                      event->button, event->time);
+      gtk_menu_popup_at_pointer (GTK_MENU (menu), (GdkEvent*)event);
       return TRUE;
     }
   }

--- a/mate-window-picker-applet/task-title.c
+++ b/mate-window-picker-applet/task-title.c
@@ -197,12 +197,14 @@ on_state_changed (WnckWindow *window,
 
   if (wnck_window_is_maximized (window))
   {
-    gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_ACTIVE);
+    gtk_widget_set_state_flags (GTK_WIDGET (title), GTK_STATE_FLAG_ACTIVE,
+                                TRUE);
     gtk_widget_show (priv->box);
   }
   else
   {
-    gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
+    gtk_widget_set_state_flags (GTK_WIDGET (title), GTK_STATE_FLAG_NORMAL,
+                               TRUE);
     gtk_widget_hide (priv->box);
   }
 }
@@ -261,14 +263,16 @@ on_active_window_changed (WnckScreen *screen,
                                    _("Log off, switch user, lock screen or "
                                      "power down the computer"));
 
-      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_ACTIVE);
+      gtk_widget_set_state_flags (GTK_WIDGET (title), GTK_STATE_FLAG_ACTIVE,
+                                  TRUE);
       gtk_widget_show (priv->box);
     }
     else
     {
       gtk_widget_set_tooltip_text (priv->button, NULL);
       gtk_widget_set_tooltip_text (GTK_WIDGET (title), NULL);
-      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
+      gtk_widget_set_state_flags (GTK_WIDGET (title), GTK_STATE_FLAG_NORMAL,
+                                  TRUE);
       gtk_widget_hide (priv->box);
     }
   }
@@ -292,12 +296,14 @@ on_active_window_changed (WnckScreen *screen,
     priv->window = act_window;
     if (wnck_window_is_maximized (act_window))
     {
-      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_ACTIVE);
+      gtk_widget_set_state_flags (GTK_WIDGET (title), GTK_STATE_FLAG_ACTIVE,
+                                  TRUE);
       gtk_widget_show (priv->box);
     }
     else
     {
-      gtk_widget_set_state (GTK_WIDGET (title), GTK_STATE_NORMAL);
+      gtk_widget_set_state_flags (GTK_WIDGET (title), GTK_STATE_FLAG_NORMAL,
+                                  TRUE);
       gtk_widget_hide (priv->box);
     }
   }

--- a/mate-window-picker-applet/task-title.c
+++ b/mate-window-picker-applet/task-title.c
@@ -106,14 +106,14 @@ on_close_clicked (GtkButton *button,
 {
   TaskTitlePrivate *priv;
   WnckWindow *window;
-  gboolean ret;
+  gboolean retval;
 
   g_return_val_if_fail (TASK_IS_TITLE (title), FALSE);
   priv = title->priv;
-  ret = FALSE;
+  retval = FALSE;
 
   if (event->button != 1 || !priv->mouse_in_close_button)
-    return ret;
+    return retval;
 
   window = wnck_screen_get_active_window (priv->screen);
 
@@ -128,16 +128,16 @@ on_close_clicked (GtkButton *button,
     gdkscreen = gtk_widget_get_screen (GTK_WIDGET (title));
     display = gdk_screen_get_display (gdkscreen);
     wnck_window_close (window, gdk_x11_display_get_user_time (display));
-    ret = TRUE;
+    retval = TRUE;
   }
   else if (priv->show_home_title)
   {
     // This is a logout click
-    ret = start_logout_dialog (title);
+    retval = start_logout_dialog (title);
   }
   gtk_widget_queue_draw (GTK_WIDGET (title));
 
-  return ret;
+  return retval;
 }
 
 static gboolean

--- a/mate-window-picker-applet/task-title.c
+++ b/mate-window-picker-applet/task-title.c
@@ -111,9 +111,10 @@ on_close_clicked (GtkButton *button,
 
   g_return_val_if_fail (TASK_IS_TITLE (title), FALSE);
   priv = title->priv;
+  ret = FALSE;
 
   if (event->button != 1 || !priv->mouse_in_close_button)
-    return FALSE;
+    return ret;
 
   window = wnck_screen_get_active_window (priv->screen);
 

--- a/mate-window-picker-applet/task-title.h
+++ b/mate-window-picker-applet/task-title.h
@@ -23,6 +23,7 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #define TASK_TYPE_TITLE (task_title_get_type ())
 

--- a/mate-window-picker-applet/task-title.h
+++ b/mate-window-picker-applet/task-title.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2008 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as 
+ * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
@@ -44,10 +44,10 @@
 typedef struct _TaskTitle        TaskTitle;
 typedef struct _TaskTitleClass   TaskTitleClass;
 typedef struct _TaskTitlePrivate TaskTitlePrivate;
- 
+
 struct _TaskTitle
 {
-  GtkEventBox        parent;	
+  GtkEventBox        parent;
 
   TaskTitlePrivate *priv;
 };
@@ -63,4 +63,3 @@ GtkWidget * task_title_new (void);
 
 
 #endif /* _TASK_TITLE_H_ */
-

--- a/maximus/main.c
+++ b/maximus/main.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2008 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as 
+ * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
@@ -39,13 +39,13 @@
 static gboolean version    = FALSE;
 gboolean no_maximize = FALSE;
 
-GOptionEntry entries[] = 
+GOptionEntry entries[] =
 {
  {
-   "version", 'v', 
-   0, G_OPTION_ARG_NONE, 
-   &version, 
-   "Prints the version number", NULL 
+   "version", 'v',
+   0, G_OPTION_ARG_NONE,
+   &version,
+   "Prints the version number", NULL
  },
  {
    "no-maximize", 'm',
@@ -53,8 +53,8 @@ GOptionEntry entries[] =
    &no_maximize,
    "Do not automatically maximize every window", NULL
  },
- { 
-   NULL 
+ {
+   NULL
  }
 };
 
@@ -67,9 +67,9 @@ gint main (gint argc, gchar *argv[])
   GdkDisplay *gdk_display;
 
   g_set_application_name ("Maximus");
-  
+
   gtk_init (&argc, &argv);
-  
+
   application = g_application_new ("com.canonical.Maximus", G_APPLICATION_FLAGS_NONE);
 
   if (!g_application_register (application, NULL, &error))
@@ -78,7 +78,7 @@ gint main (gint argc, gchar *argv[])
     g_error_free (error);
     return 1;
   }
-  
+
   if (g_application_get_is_remote(application))
   {
     return 0;
@@ -88,7 +88,7 @@ gint main (gint argc, gchar *argv[])
   g_option_context_add_main_entries (context, entries, "maximus");
   g_option_context_add_group (context, gtk_get_option_group (TRUE));
   g_option_context_parse (context, &argc, &argv, NULL);
-  g_option_context_free(context);  
+  g_option_context_free(context);
 
   gdk_display = gdk_display_get_default ();
   gdk_x11_display_error_trap_push (gdk_display);

--- a/maximus/maximus-bind.c
+++ b/maximus/maximus-bind.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2008 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as 
+ * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
@@ -76,7 +76,7 @@ struct _MaximusBindPrivate
   GList *rules;
 };
 
-typedef struct 
+typedef struct
 {
   gchar *wm_class;
   gchar *fullscreen;
@@ -94,7 +94,7 @@ get_fullscreen_keystroke (GList *rules, WnckWindow *window)
   class_name = wnck_class_group_get_name (group);
 
   g_debug ("Searching rules for %s:\n", wnck_window_get_name (window));
-  
+
   for (r = rules; r; r = r->next)
   {
     MaximusRule *rule = r->data;
@@ -152,7 +152,7 @@ real_fullscreen (MaximusBind *bind)
     return FALSE;
 
   keystroke = get_fullscreen_keystroke (priv->rules, active);
-  
+
   if (keystroke)
   {
     guint keysym = 0;
@@ -171,7 +171,7 @@ real_fullscreen (MaximusBind *bind)
       if (modifiers & EGG_VIRTUAL_META_MASK)
         mods |= FAKEKEYMOD_META;
 
-      g_debug ("Sending fullscreen special event: %s = %d %d", 
+      g_debug ("Sending fullscreen special event: %s = %d %d",
                keystroke, keysym, mods);
       fakekey_press_keysym (priv->fk, keysym, mods);
       fakekey_release (priv->fk);
@@ -223,7 +223,7 @@ real_unfullscreen (MaximusBind *bind)
 
   if (!WNCK_IS_WINDOW (active)
         || wnck_window_get_window_type (active) != WNCK_WINDOW_NORMAL)
-    return FALSE;  
+    return FALSE;
 
   keystroke = get_unfullscreen_keystroke (priv->rules, active);
 
@@ -245,14 +245,14 @@ real_unfullscreen (MaximusBind *bind)
       if (modifiers & EGG_VIRTUAL_META_MASK)
         mods |= FAKEKEYMOD_META;
 
-      g_debug ("Sending fullscreen special event: %s = %d %d", 
+      g_debug ("Sending fullscreen special event: %s = %d %d",
                keystroke, keysym, mods);
       fakekey_press_keysym (priv->fk, keysym, mods);
       fakekey_release (priv->fk);
 
       return FALSE;
      }
-  }  
+  }
   if (wnck_window_is_fullscreen (active))
   {
     g_debug ("Sending un-fullscreen F11 event");
@@ -267,7 +267,7 @@ real_unfullscreen (MaximusBind *bind)
     g_debug ("Forcing un-fullscreen wnck event");
     wnck_window_set_fullscreen (active, FALSE);
   }
-  
+
   return FALSE;
 }
 
@@ -287,7 +287,7 @@ on_binding_activated (gchar *keystring, MaximusBind *bind)
 {
   MaximusBindPrivate *priv;
   WnckWindow *active;
-  
+
   g_return_if_fail (MAXIMUS_IS_BIND (bind));
   priv = bind->priv;
 
@@ -324,19 +324,19 @@ on_binding_changed (GSettings      *settings,
                     MaximusBind    *bind)
 {
   MaximusBindPrivate *priv;
-  
+
   g_return_if_fail (MAXIMUS_IS_BIND (bind));
   priv = bind->priv;
 
   if (binding_is_valid (priv->binding))
-    tomboy_keybinder_unbind (priv->binding, 
+    tomboy_keybinder_unbind (priv->binding,
                              (TomboyBindkeyHandler)on_binding_changed);
   g_free (priv->binding);
 
   priv->binding = g_settings_get_string (settings, BIND_EXCLUDE_CLASS);
 
   if (binding_is_valid (priv->binding))
-    tomboy_keybinder_bind (priv->binding, 
+    tomboy_keybinder_bind (priv->binding,
                            (TomboyBindkeyHandler)on_binding_activated,
                            bind);
 
@@ -369,15 +369,15 @@ create_rule (MaximusBind *bind, const gchar *filename)
     return;
   }
 
-  rule = g_slice_new0 (MaximusRule); 
+  rule = g_slice_new0 (MaximusRule);
 
-  rule->wm_class = g_key_file_get_string (file, 
+  rule->wm_class = g_key_file_get_string (file,
                                           RULE_GROUP, RULE_WMCLASS,
                                           NULL);
-  rule->fullscreen = g_key_file_get_string (file, 
+  rule->fullscreen = g_key_file_get_string (file,
                                             RULE_GROUP, RULE_FULLSCREEN,
                                             NULL);
-  rule->unfullscreen = g_key_file_get_string (file, 
+  rule->unfullscreen = g_key_file_get_string (file,
                                               RULE_GROUP, RULE_UNFULLSCREEN,
                                               NULL);
   if (!rule->wm_class || !rule->fullscreen || !rule->unfullscreen)
@@ -412,7 +412,7 @@ load_rules (MaximusBind *bind, const gchar *path)
   while ((name = g_dir_read_name (dir)))
   {
     gchar *filename;
-    
+
     filename= g_build_filename (path, name, NULL);
 
     create_rule (bind, filename);
@@ -465,7 +465,7 @@ maximus_bind_init (MaximusBind *bind)
   MaximusBindPrivate *priv;
   GdkDisplay *display = gdk_display_get_default ();
   WnckScreen *screen;
-	
+
   priv = bind->priv = MAXIMUS_BIND_GET_PRIVATE (bind);
 
   priv->fk = fakekey_init (GDK_DISPLAY_XDISPLAY (display));
@@ -495,7 +495,7 @@ maximus_bind_get_default (void)
   static MaximusBind *bind = NULL;
 
   if (!bind)
-    bind = g_object_new (MAXIMUS_TYPE_BIND, 
+    bind = g_object_new (MAXIMUS_TYPE_BIND,
                        NULL);
 
   return bind;


### PR DESCRIPTION
This PR brings some love to the window picker applet:

- remove some compilation warnings
- remove runtime warning in `~/.xsession-errors` file
- add back missing settings
- [NEW] allow one to unboldify app title

This PR may also be seen as a clean working base for #39 

As a new comer to the Mate project, I'll take care of all your reviews. Do not hesitate to comment if you think I don't follow any guideline you may have. Thank you for your understanding.
