### PR TITLE
Cleanup and fix

### DIFF
--- a/mate-window-picker-applet/org.mate.panel.MateWindowPicker.mate-panel-applet.desktop.in.in
+++ b/mate-window-picker-applet/org.mate.panel.MateWindowPicker.mate-panel-applet.desktop.in.in
@@ -5,8 +5,8 @@ Name=Window Picker Applet Factory
 Description=Window Picker
 
 [MateWindowPicker]
-Name=Window Picker
-Description=Window Picker
+Name=Netbook Window Picker
+Description=Switch between open windows using their icons for small screens
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=preferences-system-windows
 BonoboId=OAFIID:MATE_WindowPicker

--- a/mate-window-picker-applet/task-item.c
+++ b/mate-window-picker-applet/task-item.c
@@ -134,7 +134,10 @@ on_task_item_button_released (GtkWidget      *widget,
     }
     if (wnck_window_is_active (window))
     {
-      wnck_window_minimize (window);
+      if (!wnck_window_is_minimized (window))
+      {
+        wnck_window_minimize (window);
+      }
     }
     else
     {

--- a/mate-window-picker-applet/task-item.c
+++ b/mate-window-picker-applet/task-item.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2012-2021 MATE Developers
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as 
+ * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
@@ -25,7 +25,7 @@
 #include <glib/gi18n.h>
 #include <cairo/cairo.h>
 
-#define DEFAULT_TASK_ITEM_HEIGHT 24;  
+#define DEFAULT_TASK_ITEM_HEIGHT 24;
 #define DEFAULT_TASK_ITEM_WIDTH 28
 
 struct _TaskItemPrivate
@@ -34,7 +34,7 @@ struct _TaskItemPrivate
   WnckScreen   *screen;
   GdkPixbuf    *pixbuf;
   GdkRectangle area;
-  
+
   GTimeVal     urgent_time;
   guint        timer;
   gboolean     mouse_over;
@@ -106,8 +106,8 @@ update_hints (TaskItem *item)
                                  allocation_widget.height);
 }
 
-static gboolean 
-on_task_item_button_released (GtkWidget      *widget, 
+static gboolean
+on_task_item_button_released (GtkWidget      *widget,
                               GdkEventButton *event,
                               TaskItem       *item)
 {
@@ -115,20 +115,19 @@ on_task_item_button_released (GtkWidget      *widget,
   WnckScreen *screen;
   WnckWorkspace *workspace;
   TaskItemPrivate *priv;
-  
+
   g_return_val_if_fail (TASK_IS_ITEM (item), TRUE);
-  
+
   priv = item->priv;
   window = priv->window;
-  
+
   g_return_val_if_fail (WNCK_IS_WINDOW (window), TRUE);
-  
+
   screen = priv->screen;
   workspace = wnck_window_get_workspace (window);
-  
+
   if (event->button == 1)
   {
-  
     if (WNCK_IS_WORKSPACE (workspace) && workspace != wnck_screen_get_active_workspace (screen))
     {
       wnck_workspace_activate (workspace, event->time);
@@ -153,23 +152,23 @@ task_item_set_visibility (TaskItem *item)
   WnckWorkspace *workspace;
 
   g_return_if_fail (TASK_IS_ITEM (item));
-  
+
   TaskItemPrivate *priv = item->priv;
-  
+
   if (!WNCK_IS_WINDOW (priv->window))
   {
     gtk_widget_hide (GTK_WIDGET (item));
     return;
   }
-  
+
   window = priv->window;
-  
+
   screen = priv->screen;
   workspace = wnck_screen_get_active_workspace (screen);
-  
+
   gboolean show_all = task_list_get_show_all_windows (TASK_LIST (task_list_get_default ()));
   gboolean show_window = FALSE;
-  
+
   if (!wnck_window_is_skip_tasklist (window))
   {
     if (workspace != NULL)
@@ -185,7 +184,7 @@ task_item_set_visibility (TaskItem *item)
     }
     show_window = show_window || show_all;
   }
-  
+
   if (show_window)
   {
     gtk_widget_show (GTK_WIDGET (item));
@@ -218,17 +217,17 @@ task_item_sized_pixbuf_for_window (TaskItem   *item,
                                    gint size)
 {
   GdkPixbuf *pbuf = NULL;
-  
+
   g_return_val_if_fail (WNCK_IS_WINDOW (window), NULL);
-  
+
   if (wnck_window_has_icon_name (window))
   {
     const gchar *icon_name = wnck_window_get_icon_name (window);
     GtkIconTheme *icon_theme = gtk_icon_theme_get_default ();
-    
+
     if (gtk_icon_theme_has_icon (icon_theme, icon_name))
     {
-      GdkPixbuf *internal = gtk_icon_theme_load_icon (icon_theme, 
+      GdkPixbuf *internal = gtk_icon_theme_load_icon (icon_theme,
                                                       icon_name,
                                                       size,
                                                       GTK_ICON_LOOKUP_FORCE_SIZE,
@@ -237,25 +236,25 @@ task_item_sized_pixbuf_for_window (TaskItem   *item,
       g_object_unref (internal);
     }
   }
-  
+
   if (!pbuf)
   {
     pbuf = gdk_pixbuf_copy (wnck_window_get_icon (item->priv->window));
   }
-  
+
   gint width = gdk_pixbuf_get_width (pbuf);
   gint height = gdk_pixbuf_get_height (pbuf);
 
   if (MAX (width, height) != size)
   {
     gdouble scale = (gdouble) size / (gdouble) MAX (width, height);
-  
+
     GdkPixbuf *tmp = pbuf;
     pbuf = gdk_pixbuf_scale_simple (tmp, (gint) (width * scale), (gint) (height * scale), GDK_INTERP_HYPER);
-    
+
     g_object_unref (tmp);
   }
- 
+
   return pbuf;
 }
 static gboolean
@@ -267,32 +266,32 @@ task_item_draw (GtkWidget      *widget,
   GdkRectangle area;
   TaskItemPrivate *priv;
   GdkPixbuf *pbuf;
-  
+
   g_return_val_if_fail (widget != NULL, FALSE);
   g_return_val_if_fail (TASK_IS_ITEM (widget), FALSE);
-  
+
   item = TASK_ITEM (widget);
   priv = item->priv;
-  
+
   g_return_val_if_fail (WNCK_IS_WINDOW (priv->window), FALSE);
-  
+
   area = priv->area;
   cr = gdk_cairo_create (gtk_widget_get_window (widget));
-  
+
   pbuf = priv->pixbuf;
-  
+
   gint size = MIN (area.height, area.width);
   gboolean active = wnck_window_is_active (priv->window);
   gboolean attention = wnck_window_or_transient_needs_attention (priv->window);
-  
-  if (GDK_IS_PIXBUF (pbuf) && 
+
+  if (GDK_IS_PIXBUF (pbuf) &&
       gdk_pixbuf_get_width (pbuf) != size &&
       gdk_pixbuf_get_height (pbuf) != size)
   {
     g_object_unref (pbuf);
     pbuf = NULL;
   }
-  
+
   if (active)
   {
     cairo_rectangle (cr, area.x + 1, area.y - 1, area.width - 2, area.height - 2);
@@ -326,17 +325,17 @@ task_item_draw (GtkWidget      *widget,
     cairo_paint (cr);
     cairo_pattern_destroy (glow_pattern);
   }
-  
+
   if (!pbuf)
   {
     pbuf = priv->pixbuf = task_item_sized_pixbuf_for_window (item, priv->window, size);
   }
-  
+
   if (active || priv->mouse_over || attention)
   {
-    gdk_cairo_set_source_pixbuf (cr, 
-                                 pbuf, 
-                                 (area.x + (area.width - gdk_pixbuf_get_width (pbuf)) / 2), 
+    gdk_cairo_set_source_pixbuf (cr,
+                                 pbuf,
+                                 (area.x + (area.width - gdk_pixbuf_get_width (pbuf)) / 2),
                                  (area.y + (area.height - gdk_pixbuf_get_height (pbuf)) / 2));
   }
   else
@@ -346,7 +345,7 @@ task_item_draw (GtkWidget      *widget,
                             gdk_pixbuf_get_bits_per_sample (pbuf),
                             gdk_pixbuf_get_width (pbuf),
                             gdk_pixbuf_get_height (pbuf));
-    
+
     if (desat)
     {
       gdk_pixbuf_saturate_and_pixelate (pbuf,
@@ -358,9 +357,9 @@ task_item_draw (GtkWidget      *widget,
     {
       desat = g_object_ref (pbuf);
     }
-    gdk_cairo_set_source_pixbuf (cr, 
-                                 desat, 
-                                 (area.x + (area.width - gdk_pixbuf_get_width (desat)) / 2), 
+    gdk_cairo_set_source_pixbuf (cr,
+                                 desat,
+                                 (area.x + (area.width - gdk_pixbuf_get_width (desat)) / 2),
                                  (area.y + (area.height - gdk_pixbuf_get_height (desat)) / 2));
     g_object_unref (desat);
   }
@@ -368,10 +367,10 @@ task_item_draw (GtkWidget      *widget,
   {
     GTimeVal current_time;
     g_get_current_time (&current_time);
-    
-    gdouble ms = (current_time.tv_sec - priv->urgent_time.tv_sec) * 1000 + 
+
+    gdouble ms = (current_time.tv_sec - priv->urgent_time.tv_sec) * 1000 +
                  (current_time.tv_usec - priv->urgent_time.tv_usec) / 1000;
-    
+
     gdouble alpha = .66 + (cos (3.15 * ms / 600) / 3);
     cairo_paint_with_alpha (cr, alpha);
   }
@@ -385,7 +384,7 @@ task_item_draw (GtkWidget      *widget,
   }
 
   cairo_destroy (cr);
-  
+
   return FALSE;
 }
 
@@ -395,19 +394,19 @@ on_size_allocate (GtkWidget     *widget,
                   TaskItem      *item)
 {
   TaskItemPrivate *priv;
-  
+
   if (allocation->width != allocation->height + 6)
     gtk_widget_set_size_request (widget, allocation->height + 6, -1);
 
   g_return_if_fail (TASK_IS_ITEM (item));
-  
+
   priv = item->priv;
   priv->area.x = allocation->x;
   priv->area.y = allocation->y;
   priv->area.width = allocation->width;
   priv->area.height = allocation->height;
 
-  update_hints (item);    
+  update_hints (item);
 }
 
 static gboolean
@@ -433,8 +432,8 @@ on_button_pressed (GtkWidget      *button,
 
 static gboolean
 on_query_tooltip (GtkWidget *widget,
-                  gint x, gint y, 
-                  gboolean keyboard_mode, 
+                  gint x, gint y,
+                  gboolean keyboard_mode,
                   GtkTooltip *tooltip,
                   TaskItem *item)
 {
@@ -453,10 +452,10 @@ on_enter_notify (GtkWidget *widget,
                  TaskItem *item)
 {
   g_return_val_if_fail (TASK_IS_ITEM (item), FALSE);
-  
+
   item->priv->mouse_over = TRUE;
   gtk_widget_queue_draw (widget);
-  
+
   return FALSE;
 }
 
@@ -466,7 +465,7 @@ on_leave_notify (GtkWidget *widget,
                  TaskItem *item)
 {
   g_return_val_if_fail (TASK_IS_ITEM (item), FALSE);
-  
+
   item->priv->mouse_over = FALSE;
   gtk_widget_queue_draw (widget);
 
@@ -499,15 +498,15 @@ on_window_state_changed (WnckWindow      *window,
 {
   g_return_if_fail (WNCK_IS_WINDOW (window));
   g_return_if_fail (TASK_IS_ITEM (item));
-  
+
   TaskItemPrivate *priv = item->priv;
-  
+
   if (new_state & WNCK_WINDOW_STATE_URGENT && !priv->timer)
   {
     priv->timer = g_timeout_add (30, (GSourceFunc)on_blink, item);
     g_get_current_time (&priv->urgent_time);
   }
-  
+
   task_item_set_visibility (item);
 }
 
@@ -523,17 +522,17 @@ static void
 on_window_icon_changed (WnckWindow *window, TaskItem *item)
 {
   TaskItemPrivate *priv;
-  
+
   g_return_if_fail (TASK_IS_ITEM (item));
-  
+
   priv = item->priv;
-  
+
   if (GDK_IS_PIXBUF (priv->pixbuf))
   {
     g_object_unref (priv->pixbuf);
     priv->pixbuf = NULL;
   }
-  
+
   gtk_widget_queue_draw (GTK_WIDGET (item));
 }
 
@@ -549,9 +548,9 @@ on_screen_active_window_changed (WnckScreen    *screen,
 
   priv = item->priv;
   window = priv->window;
-  
+
   g_return_if_fail (WNCK_IS_WINDOW (window));
-  
+
   if ((WNCK_IS_WINDOW (old_window) && window == old_window) ||
        window == wnck_screen_get_active_window (screen))
   {
@@ -585,7 +584,7 @@ on_screen_window_closed (WnckScreen  *screen,
                          TaskItem    *item)
 {
   TaskItemPrivate *priv;
- 
+
   g_return_if_fail (TASK_IS_ITEM (item));
   priv = item->priv;
   g_return_if_fail (WNCK_IS_WINDOW (priv->window));
@@ -599,7 +598,7 @@ on_screen_window_closed (WnckScreen  *screen,
     g_signal_handlers_disconnect_by_func (window, G_CALLBACK (on_window_workspace_changed), item);
     g_signal_handlers_disconnect_by_func (window, G_CALLBACK (on_window_state_changed), item);
     g_signal_handlers_disconnect_by_func (window, G_CALLBACK (on_window_icon_changed), item);
-  
+
     g_signal_emit (G_OBJECT (item), task_item_signals[TASK_ITEM_CLOSED_SIGNAL], 0);
   }
 }
@@ -614,22 +613,22 @@ activate_window (GtkWidget *widget)
   g_return_val_if_fail (TASK_IS_ITEM (widget), FALSE);
 
   priv = TASK_ITEM (widget)->priv;
-  
+
   g_return_val_if_fail (WNCK_IS_WINDOW (priv->window), FALSE);
 
   active = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (widget), "drag-true"));
 
   if (active)
-  { 
+  {
     WnckWindow *window;
 
     window = priv->window;
     if (WNCK_IS_WINDOW (window))
       wnck_window_activate (window, time (NULL));
   }
-  
+
   g_object_set_data (G_OBJECT (widget), "drag-true", GINT_TO_POINTER (0));
-  
+
   return FALSE;
 }
 
@@ -644,14 +643,14 @@ on_drag_leave (GtkWidget      *item,
 static gboolean
 on_drag_motion (GtkWidget      *item,
                 GdkDragContext *context,
-                gint            x, 
+                gint            x,
                 gint            y,
                 guint           t)
 {
   gint active;
 
   active = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (item), "drag-true"));
-  
+
   if (!active)
   {
     g_object_set_data (G_OBJECT (item), "drag-true", GINT_TO_POINTER (1));
@@ -669,15 +668,15 @@ task_item_setup_atk (TaskItem *item)
   GtkWidget *widget;
   AtkObject *atk;
   WnckWindow *window;
-  
+
   g_return_if_fail (TASK_IS_ITEM (item));
-  
+
   widget = GTK_WIDGET (item);
   priv = item->priv;
   window = priv->window;
-  
+
   g_return_if_fail (WNCK_IS_WINDOW (window));
-  
+
   atk = gtk_widget_get_accessible (widget);
   atk_object_set_name (atk, _("Window Task Button"));
   atk_object_set_description (atk, wnck_window_get_name (window));
@@ -711,7 +710,7 @@ task_item_finalize (GObject *object)
   {
     g_source_remove (priv->timer);
   }
-  
+
   if (GDK_IS_PIXBUF (priv->pixbuf))
   {
     g_object_unref (priv->pixbuf);
@@ -757,36 +756,36 @@ task_item_new (WnckWindow *window)
   TaskItem *task;
   TaskItemPrivate *priv;
   WnckScreen *screen;
-  
+
   g_return_val_if_fail (WNCK_IS_WINDOW (window), item);
 
-  item = g_object_new (TASK_TYPE_ITEM, 
+  item = g_object_new (TASK_TYPE_ITEM,
                        "has-tooltip", TRUE,
-                       "visible-window", FALSE, 
-                       "above-child", TRUE, 
+                       "visible-window", FALSE,
+                       "above-child", TRUE,
                        NULL);
-                       
+
   gtk_widget_add_events (item, GDK_ALL_EVENTS_MASK);
   gtk_container_set_border_width (GTK_CONTAINER (item), 0);
 
   task = TASK_ITEM (item);
-  priv = task->priv;  
+  priv = task->priv;
   priv->window = window;
-  
+
   screen = wnck_window_get_screen (window);
   priv->screen = screen;
-  
+
   gtk_drag_dest_set (item,
                      GTK_DEST_DEFAULT_MOTION | GTK_DEST_DEFAULT_DROP,
                      drop_types, n_drop_types,
                      GDK_ACTION_COPY);
   gtk_drag_dest_add_uri_targets (item);
   gtk_drag_dest_add_text_targets (item);
-  g_signal_connect (item, "drag-motion", 
+  g_signal_connect (item, "drag-motion",
                     G_CALLBACK (on_drag_motion), NULL);
-  g_signal_connect (item, "drag-leave", 
+  g_signal_connect (item, "drag-leave",
                     G_CALLBACK (on_drag_leave), NULL);
-  
+
   g_signal_connect (screen, "viewports-changed",
                     G_CALLBACK (on_screen_active_viewport_changed), item);
   g_signal_connect (screen, "active-window-changed",
@@ -795,21 +794,21 @@ task_item_new (WnckWindow *window)
                     G_CALLBACK (on_screen_active_workspace_changed), item);
   g_signal_connect (screen, "window-closed",
                     G_CALLBACK (on_screen_window_closed), item);
-                    
+
   g_signal_connect (window, "workspace-changed",
   		    G_CALLBACK (on_window_workspace_changed), item);
   g_signal_connect (window, "state-changed",
                     G_CALLBACK (on_window_state_changed), item);
   g_signal_connect (window, "icon-changed",
                     G_CALLBACK (on_window_icon_changed), item);
-  
+
   g_signal_connect (item, "button-release-event",
                     G_CALLBACK (on_task_item_button_released), item);
   g_signal_connect (item, "button-press-event",
                     G_CALLBACK (on_button_pressed), item);
   g_signal_connect (item, "size-allocate",
                     G_CALLBACK (on_size_allocate), item);
-  g_signal_connect (item, "query-tooltip", 
+  g_signal_connect (item, "query-tooltip",
                     G_CALLBACK (on_query_tooltip), item);
   g_signal_connect (item, "enter-notify-event",
                     G_CALLBACK (on_enter_notify), item);
@@ -819,9 +818,9 @@ task_item_new (WnckWindow *window)
                     G_CALLBACK (on_drag_motion), item);
   g_signal_connect (item, "drag-leave",
                     G_CALLBACK (on_drag_leave), item);
-                    
+
   task_item_set_visibility (task);
   task_item_setup_atk (task);
-  
+
   return item;
 }

--- a/maximus/main.c
+++ b/maximus/main.c
@@ -31,12 +31,6 @@
 
 #include "maximus-app.h"
 
-#ifdef __GNUC__
-#define UNUSED_VARIABLE __attribute__ ((unused))
-#else
-#define UNUSED_VARIABLE
-#endif
-
 static gboolean version    = FALSE;
 gboolean no_maximize = FALSE;
 
@@ -62,7 +56,6 @@ GOptionEntry entries[] =
 gint main (gint argc, gchar *argv[])
 {
   GApplication *application;
-  MaximusApp UNUSED_VARIABLE *app;
   GOptionContext  *context;
   GError *error = NULL;
   GdkDisplay *gdk_display;
@@ -93,7 +86,8 @@ gint main (gint argc, gchar *argv[])
 
   gdk_display = gdk_display_get_default ();
   gdk_x11_display_error_trap_push (gdk_display);
-  app = maximus_app_get_default ();
+  // Initialize app, but don't reference return value
+  maximus_app_get_default ();
   gdk_x11_display_error_trap_pop_ignored (gdk_display);
 
   gtk_main ();

--- a/maximus/maximus-bind.c
+++ b/maximus/maximus-bind.c
@@ -54,12 +54,6 @@
 
 #define SYSRULESDIR SYSCONFDIR"/maximus"
 
-#ifdef __GNUC__
-#define UNUSED_VARIABLE __attribute__ ((unused))
-#else
-#define UNUSED_VARIABLE
-#endif
-
 struct _MaximusBindPrivate
 {
   FakeKey *fk;
@@ -135,13 +129,11 @@ static gboolean
 real_fullscreen (MaximusBind *bind)
 {
   MaximusBindPrivate *priv;
-  GdkDisplay UNUSED_VARIABLE *display;
   WnckWindow *active;
   const gchar *keystroke;
 
   priv = bind->priv;
 
-  display = gdk_display_get_default ();
   active = wnck_screen_get_active_window (priv->screen);
 
   if (!WNCK_IS_WINDOW (active)
@@ -198,10 +190,6 @@ real_fullscreen (MaximusBind *bind)
 static void
 fullscreen (MaximusBind *bind, WnckWindow *window)
 {
-  MaximusBindPrivate UNUSED_VARIABLE *priv;
-  
-  priv = bind->priv;
-
   g_timeout_add (KEY_RELEASE_TIMEOUT, (GSourceFunc)real_fullscreen, bind);
 }
 
@@ -209,13 +197,11 @@ static gboolean
 real_unfullscreen (MaximusBind *bind)
 {
   MaximusBindPrivate *priv;
-  GdkDisplay UNUSED_VARIABLE *display;
   WnckWindow *active;
   const gchar *keystroke;
 
   priv = bind->priv;
 
-  display = gdk_display_get_default ();
   active = wnck_screen_get_active_window (priv->screen);
 
   if (!WNCK_IS_WINDOW (active)
@@ -271,10 +257,6 @@ real_unfullscreen (MaximusBind *bind)
 static void
 unfullscreen (MaximusBind *bind, WnckWindow *window)
 {
-  MaximusBindPrivate UNUSED_VARIABLE *priv;
-  
-  priv = bind->priv;
-
   g_timeout_add (KEY_RELEASE_TIMEOUT, (GSourceFunc)real_unfullscreen, bind);
 }
 
@@ -393,11 +375,8 @@ create_rule (MaximusBind *bind, const gchar *filename)
 static void
 load_rules (MaximusBind *bind, const gchar *path)
 {
-  MaximusBindPrivate UNUSED_VARIABLE *priv;
   GDir *dir;
   const gchar *name;
-
-  priv = bind->priv;
 
   dir = g_dir_open (path, 0, NULL);
 


### PR DESCRIPTION
This PR features the following things:

- fix window's states regression (several windows could be active and minified in the same time, resulting in the impossibility to raised them back)
- improve widget discoverability by changing its name to not confuse it with the generic one provided by mate-panel
- bump applet copyright date
- another code cleanup pass.