### PR TITLE
mate-maximus-autostart.desktop: The Encoding key is deprecated

### DIFF
--- a/maximus/mate-maximus-autostart.desktop
+++ b/maximus/mate-maximus-autostart.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Maximus Window Management
 Comment=Controls the displaying of windows
 Icon=preferences-system-windows


### PR DESCRIPTION
https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html