### PR TITLE
maximus: fix build warning about missing field initializer

### DIFF
--- a/maximus/main.c
+++ b/maximus/main.c
@@ -55,7 +55,7 @@ GOptionEntry entries[] =
    "Do not automatically maximize every window", NULL
  },
  {
-   NULL
+   NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL
  }
 };
 


### PR DESCRIPTION
```
main.c:59:2: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
 }
 ^
```