### PR TITLE
Fix undecorate on maximise

### DIFF
--- a/maximus/maximus-app.c
+++ b/maximus/maximus-app.c
@@ -305,8 +305,7 @@ is_excluded (MaximusApp *app, WnckWindow *window)
   
   /* Make sure the window supports maximising */
   actions = wnck_window_get_actions (window);
-  if (actions & WNCK_WINDOW_ACTION_RESIZE
-      && actions & WNCK_WINDOW_ACTION_MAXIMIZE_HORIZONTALLY
+  if (actions & WNCK_WINDOW_ACTION_MAXIMIZE_HORIZONTALLY
       && actions & WNCK_WINDOW_ACTION_MAXIMIZE_VERTICALLY
       && actions & WNCK_WINDOW_ACTION_MAXIMIZE)
     ; /* Is good to maximise */


### PR DESCRIPTION
WNCK_WINDOW_ACTION_RESIZE is not always included in 'actions', almost never when using e.g. picom,
so this won't check for that any more, making undecorate on maximise work reliably.

Fixes https://github.com/mate-desktop/mate-netbook/issues/63